### PR TITLE
Don't fail on funopen() on Android

### DIFF
--- a/src/funopen.c
+++ b/src/funopen.c
@@ -143,6 +143,10 @@ funopen(const void *cookie,
  * they will not add the needed support to implement it. Just ignore this
  * interface there, as it has never been provided anyway.
  */
+#elif defined(__ANDROID__)
+/*
+ * The Android NDK sysroot does not have fopencookie.
+ */
 #else
 #error "Function funopen() needs to be ported or disabled."
 #endif


### PR DESCRIPTION
Android does not seem to provide fopencookie(). It looks like this is the only reason the library won't cross-compile to the NDK. It seems like a low cost thing to go the same way as in the prior special case, and just not define the function for that platform.